### PR TITLE
Ap/include libraries

### DIFF
--- a/CsharpRAPL/Benchmarking/CompileCBenchmarks.sh
+++ b/CsharpRAPL/Benchmarking/CompileCBenchmarks.sh
@@ -16,10 +16,10 @@ else
   echo -n "No additional compiler options found... " || exit 1
 fi
 
-gcc -c cmd.c -o cmd.o || exit 1
-gcc -c scomm.c -o scomm.o || exit 1
-gcc -c "$2" -o bench.o || exit 1
-gcc main.c cmd.o scomm.o bench.o -o CBench $SUBSTRING || exit 1
+#gcc -c cmd.c -o cmd.o || exit 1
+#gcc -c scomm.c -o scomm.o || exit 1
+#gcc -c "$2" -o bench.o || exit 1
+gcc main.c "$2" -o CBench $SUBSTRING  || exit 1
 
 echo "Done!"
 exit 0

--- a/CsharpRAPL/Benchmarking/CompileJavaBenchmarks.sh
+++ b/CsharpRAPL/Benchmarking/CompileJavaBenchmarks.sh
@@ -16,15 +16,16 @@ fi
 
 
 cd "$1" || exit 1
-
 echo -n "Compiling... "
-SUBSTRING=$(echo "$3"| cut -d'"' -f 2) || exit 1
+SUBSTRING=$(echo "$4"| cut -d'"' -f 2) || exit 1
+FLAG=$(echo "$3" | cut -d' ' -f 1) || exit 1
+CP=$(echo "$3" | cut -d' ' -f 2) || exit 1
 if test "$SUBSTRING" != "" ; then
   echo -n "Compiler options: $SUBSTRING... "
-  javac *.java "$SUBSTRING" || exit 1
+  javac "$FLAG" "$CP" "$SUBSTRING" *.java  || exit 1
 else
   echo -n "No additional compiler options found... "
-  javac *.java || exit 1
+  javac "$FLAG" "$CP" *.java || exit 1
 fi
 
 jar -cmf MANIFEST.MF JavaBench.jar *.class || exit 1

--- a/CsharpRAPL/Benchmarking/Lifecycles/CState.cs
+++ b/CsharpRAPL/Benchmarking/Lifecycles/CState.cs
@@ -16,6 +16,10 @@ public class CState : IpcState {
 	public string LibPath { get; set; }
 	private List<string> _libs = new List<string>{"libSocketComm.a"};
 	private List<string> _includes = new List<string>{"SocketComm"};
+	
+	/// <summary>
+	/// List of library files relative to LibPath/lib to link in compilation
+	/// </summary>
 	public List<string> Libs {
 		get => _libs;
 		set {
@@ -26,6 +30,9 @@ public class CState : IpcState {
 		}
 	}
 
+	/// <summary>
+	/// List of include directories relative to LibPath/include to include in compilation
+	/// </summary>
 	public List<string> Includes {
 		get => _includes;
 		set {
@@ -53,6 +60,9 @@ public class CState : IpcState {
 
 	private string _sendSignature;
 
+	/// <summary>
+	/// C code for sending benchmark result to benchmarkrunner 
+	/// </summary>
 	public string SendSignature {
 		get => _sendSignature;
 		set {

--- a/CsharpRAPL/Benchmarking/Lifecycles/CState.cs
+++ b/CsharpRAPL/Benchmarking/Lifecycles/CState.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Accord.Math;
 using SocketComm;
 
@@ -12,6 +14,27 @@ public class CState : IpcState {
 	public string CFile { get; set; }
 	public string HeaderFile { get; set; }
 	public string LibPath { get; set; }
+	private List<string> _libs = new List<string>{"libSocketComm.a"};
+	private List<string> _includes = new List<string>{"SocketComm"};
+	public List<string> Libs {
+		get => _libs;
+		set {
+		var result = new List<string>();
+		result.Add("libSocketComm.a");
+		result.AddRange(value);
+		_libs = result;
+		}
+	}
+
+	public List<string> Includes {
+		get => _includes;
+		set {
+			var result = new List<string>();
+			result.Add("SocketComm");
+			result.AddRange(value);
+			_includes = result;
+		}
+	}
 	
 	public string? AdditionalCompilerOptions { get; set; }
 
@@ -28,9 +51,21 @@ public class CState : IpcState {
 		}
 	}
 
+	private string _sendSignature;
+
+	public string SendSignature {
+		get => _sendSignature;
+		set {
+			_sendSignature = value;
+			if (!value.EndsWith(";")) {
+				_sendSignature += ";";
+			}
+		}
+	}
+
 	protected override IpcState Generate() {
 		//Create directories and copy lib
-		string[] filesToCopy = {"cmd.c","cmd.h","scomm.c","scomm.h", CFile, HeaderFile };
+		string[] filesToCopy = {CFile, HeaderFile };
 		var dt = DateTime.Now;
 		var dir= Directory.CreateDirectory($"tmp/CBench/{BenchmarkSignature}-{dt.ToString("s").Replace(":", "-")}-{dt.Millisecond}");
 		CompilationPath = dir.FullName;
@@ -38,17 +73,31 @@ public class CState : IpcState {
 			File.Copy($"{LibPath}/{f}",$"{dir.FullName}/{f}");
 		}
 		
+		//Add includes and libraries to compiler options
+		var libs = Path.GetFullPath(LibPath + "/lib");
+		var includes = Path.GetFullPath(LibPath + "/include");
+		AdditionalCompilerOptions = $"-L{libs} " + AdditionalCompilerOptions;
+		foreach (var include in Includes) {
+			AdditionalCompilerOptions = $"-I{includes}/{include} " + AdditionalCompilerOptions;
+		}
+		foreach (var lib in Libs) {
+			AdditionalCompilerOptions += $" -l:{lib}";
+		}
+
 		//Write main file
-		var main = File.ReadAllLines(LibPath + "/main.c");
-		var includeLine = main.First(s => s.Contains("///Includes here"));
-		var benchmarkLine = main.First(s => s.Contains("///Compute benchmark here"));
-		main[benchmarkLine] = BenchmarkSignature;
-		main[includeLine] = $"#include \"{HeaderFile}\"";
-		File.WriteAllLines(dir.FullName + "/main.c", main);
+		var mainFile = File.ReadAllLines(LibPath + "/main.c");
+
+		var includeLine = mainFile.First(s => s.Contains("///Includes here"));
+		var benchmarkLine = mainFile.First(s => s.Contains("///Compute benchmark here"));
+		var sendLine = mainFile.First(s => s.Contains("///Send return value here"));
+		mainFile[benchmarkLine] = BenchmarkSignature;
+		mainFile[includeLine] = $"#include \"{HeaderFile}\"";
+		mainFile[sendLine] = SendSignature;
+		File.WriteAllLines(dir.FullName + "/main.c", mainFile);
 		
 		//Run compile script
 		var compile = new ProcessStartInfo("CompileCBenchmarks.sh");
-		compile.Arguments = $"{dir.FullName} {CFile} \"{AdditionalCompilerOptions}\"";
+		compile.Arguments = $"\"{dir.FullName}\" {CFile} \"{AdditionalCompilerOptions}\"";
 		compile.CreateNoWindow = true;
 		compile.UseShellExecute = true;
 		var compP = Process.Start(compile);

--- a/CsharpRAPL/Benchmarking/Lifecycles/IBenchmarkLifecycle.cs
+++ b/CsharpRAPL/Benchmarking/Lifecycles/IBenchmarkLifecycle.cs
@@ -27,8 +27,9 @@ public interface IBenchmarkLifecycle <T> : IBenchmarkLifecycle{
 	public new T Initialize(IBenchmark benchmark); //TODO: should be fine.... create tests 
 	public T WarmupIteration(T oldstate);
 	public T PreRun(T oldstate);
-	public object Run(T state);
+	public T Run(T state);
 	public T PostRun(T oldstate);
 	public T AdjustLoopIterations(T oldstate);
 	public T End(T oldstate);
+	
 }

--- a/CsharpRAPL/Benchmarking/Lifecycles/IpcState.cs
+++ b/CsharpRAPL/Benchmarking/Lifecycles/IpcState.cs
@@ -23,6 +23,10 @@ public class IpcState {
 	protected string CompilationPath { get; set; }
 	public bool KeepCompilationResults = false;
 
+	public Func<IpcState,IpcState> prerun = s => s;
+
+	public Func<IpcState,IpcState> postrun = s => s;
+
 	protected virtual IpcState Generate() => this;
 
 	protected virtual void OnPipeListening(object? sender, EventArgs e) {

--- a/CsharpRAPL/Benchmarking/Lifecycles/NopBenchmarkLifecycle.cs
+++ b/CsharpRAPL/Benchmarking/Lifecycles/NopBenchmarkLifecycle.cs
@@ -68,7 +68,7 @@ public class NopBenchmarkLifecycle : IBenchmarkLifecycle<IBenchmark> {
 	public IBenchmark PostRun(IBenchmark oldstate) => oldstate;
 	public IBenchmark PreRun(IBenchmark oldstate) => oldstate;
 
-	public object Run(IBenchmark state) {
+	public IBenchmark Run(IBenchmark state) {
 		object? instance = BenchmarkedMethod.IsStatic ? null : Activator.CreateInstance(BenchmarkedMethod.DeclaringType!);
 		var parameters = this.GetParameters();
 		BenchmarkedMethod.Invoke(instance, parameters);

--- a/CsharpRAPL/CsharpRAPL.csproj
+++ b/CsharpRAPL/CsharpRAPL.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <PackageVersion>1.4.1</PackageVersion>
+        <PackageVersion>1.4.2</PackageVersion>
         <PackageId>CsharpRAPL</PackageId>
         <Company>Aalborg University</Company>
         <Title>PL_CsharpRAPL</Title>
@@ -28,7 +28,7 @@
         <PackageReference Include="CsvHelper" Version="27.2.1" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="ScottPlot" Version="4.1.27" />
-        <PackageReference Include="SocketComm" Version="1.1.1" />
+        <PackageReference Include="SocketComm" Version="1.1.2.2" />
         <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     </ItemGroup>
 


### PR DESCRIPTION
Adds easier support for including libraries such that the IPC library only needs to be present once on the computer and not copied into each project. 


Also adds support for sending input values and receive result via ipc